### PR TITLE
Update Claude workflow: API key auth, MCP, and custom instructions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,21 +30,35 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Project Setup
+        run: |
+            npm run dev
+            npm run dev:daemon
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{secrets.ANTHROPIC_API_KEY}}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
+          custom_instructions: |
+              The project is already set up with all dependencies installed.
+              The server is already running at localhost:3000. Logs from it
+              are being written to logs.txt. If needed, you can query the
+              db with the 'sqlite3' cli. If needed, use the mcp__playwright
+              set of tools to launch a browser and interact with the app.
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          mcp_config: |
+              {
+                "mcpServers": {
+                  "playwright": {
+                    "command":"npx"
+                    "args": [
+                      "@playwright/mcp@latest",
+                      "--allowed-origins",
+                      "localhost:3000;cdn.tailwindcss.com;esm.sh"
+                    ]
+                  }
+                }
+              }
+          allowed_tools: "Bash(npm:*),Bash(sqlite3:*),mcp__playwright__browser_snapshot,mcp__playwright__browser_click,..."


### PR DESCRIPTION
## Summary

- Switch authentication from `CLAUDE_CODE_OAUTH_TOKEN` to `ANTHROPIC_API_KEY`
- Add project setup step that starts the dev server before Claude runs
- Add custom instructions giving Claude context about the running server, logs, and SQLite DB
- Configure Playwright MCP server for browser-based UI interactions with the app
- Restrict `allowed_tools` to `npm`, `sqlite3`, and Playwright MCP tools

## Test plan

- [ ] Verify `ANTHROPIC_API_KEY` secret is set in repo settings
- [ ] Trigger the workflow on a PR and confirm Claude runs successfully
- [ ] Confirm Playwright MCP tools are available to Claude during the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)