### PR TITLE
Fix Claude workflow: switch to OAuth token auth

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{secrets.ANTHROPIC_API_KEY}}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           custom_instructions: |
               The project is already set up with all dependencies installed.


### PR DESCRIPTION
## Summary

- Replace `anthropic_api_key` with `claude_code_oauth_token` to match the secret configured in this repository

## Test plan

- [ ] Trigger workflow by mentioning `@claude` on an issue or PR comment
- [ ] Confirm Claude runs without authentication errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)