### PR TITLE
Fix Claude workflow: proper project setup before Claude runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Project Setup
         run: |
-            npm run dev
+            npm run setup
             npm run dev:daemon
 
       - name: Run Claude Code


### PR DESCRIPTION
## Summary

- Replace broken `npm run dev` (blocking, no deps) with `npm run setup` + `npm run dev:daemon`
- `npm run setup` installs dependencies and runs Prisma generate + migrate
- `npm run dev:daemon` starts the server in the background so Claude can run after

Fixes #5

## Test plan

- [ ] Trigger workflow with `@claude` on an issue or PR comment
- [ ] Confirm the Project Setup step completes without errors
- [ ] Confirm Claude runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)