### PR TITLE
fix: toggle button tests + Coca-Cola brand colors

### DIFF
--- a/src/app/__tests__/main-content.test.tsx
+++ b/src/app/__tests__/main-content.test.tsx
@@ -1,0 +1,134 @@
+import { test, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MainContent } from "../main-content";
+
+// Mock resizable components (can't use ResizablePanel in jsdom)
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  ),
+  ResizablePanel: ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+
+// Mock heavy child components
+vi.mock("@/components/chat/ChatInterface", () => ({
+  ChatInterface: () => <div data-testid="chat-interface">Chat</div>,
+}));
+
+vi.mock("@/components/editor/FileTree", () => ({
+  FileTree: () => <div data-testid="file-tree">FileTree</div>,
+}));
+
+vi.mock("@/components/editor/CodeEditor", () => ({
+  CodeEditor: () => <div data-testid="code-editor">CodeEditor</div>,
+}));
+
+vi.mock("@/components/preview/PreviewFrame", () => ({
+  PreviewFrame: () => <div data-testid="preview-frame">PreviewFrame</div>,
+}));
+
+vi.mock("@/components/HeaderActions", () => ({
+  HeaderActions: () => <div data-testid="header-actions" />,
+}));
+
+// Mock context providers to avoid DB/API dependencies
+vi.mock("@/lib/contexts/file-system-context", () => ({
+  FileSystemProvider: ({ children }: any) => <>{children}</>,
+}));
+
+vi.mock("@/lib/contexts/chat-context", () => ({
+  ChatProvider: ({ children }: any) => <>{children}</>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+test("renders Preview and Code toggle buttons", () => {
+  render(<MainContent />);
+
+  expect(screen.getByRole("tab", { name: "Preview" })).toBeDefined();
+  expect(screen.getByRole("tab", { name: "Code" })).toBeDefined();
+});
+
+test("shows PreviewFrame by default", () => {
+  render(<MainContent />);
+
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+});
+
+test("switches to code view when Code tab is clicked", () => {
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+});
+
+test("switches back to preview when Preview tab is clicked after Code", () => {
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  fireEvent.click(previewTab);
+
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+});
+
+test("Preview tab is active by default", () => {
+  render(<MainContent />);
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  expect(previewTab.getAttribute("data-state")).toBe("active");
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  expect(codeTab.getAttribute("data-state")).toBe("inactive");
+});
+
+test("Code tab becomes active after clicking it", () => {
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+
+  expect(codeTab.getAttribute("data-state")).toBe("active");
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  expect(previewTab.getAttribute("data-state")).toBe("inactive");
+});
+
+test("clicking Code tab fires the view change action", () => {
+  render(<MainContent />);
+
+  // Start in preview
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+
+  // Click Code - action must execute and show code editor
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+  expect(screen.getByTestId("file-tree")).toBeDefined();
+});
+
+test("shows chat interface regardless of active view", () => {
+  render(<MainContent />);
+
+  expect(screen.getByTestId("chat-interface")).toBeDefined();
+
+  fireEvent.click(screen.getByRole("tab", { name: "Code" }));
+
+  expect(screen.getByTestId("chat-interface")).toBeDefined();
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,8 +52,8 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.53 0.26 27);
+  --primary-foreground: oklch(1 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);


### PR DESCRIPTION
Closes #7

- Add MainContent toggle tests verifying Preview/Code tab switching fires the view change and renders the correct content
- Update `--primary` CSS variable from black to Coca-Cola red (`oklch(0.53 0.26 27)` ≈ #F40009)

Generated with [Claude Code](https://claude.ai/code)